### PR TITLE
fix: выделение нод

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import Pages from '@/components/Pages/Pages';
 import { NodeTypes } from './interface';
 import StartWindow from '../StartWindow/StartWindow';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { flowActions } from '@/redux/flow/slice/flowSlice';
 import { useCurrentPage } from '@/hooks/useCurrentPage';
 import { NodeData } from '@/redux/flow/constants/constants';
@@ -33,8 +33,16 @@ function Main() {
     URL.revokeObjectURL(href);
   }, [pages, currentPageId]);
 
+  const divRef = useRef(null);
+
+  const onClickOutSide = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (divRef.current && divRef.current.contains(e.target)) {
+      dispatch(flowActions.onReleaseNodes());
+    }
+  }, []);
+
   return (
-    <div style={{ height: '100vh', width: '100vw' }}>
+    <div ref={divRef} style={{ height: '100vh', width: '100vw' }} onClick={onClickOutSide}>
       {currentPage ? (
         <>
           <div style={{ position: 'fixed', top: '15px', left: '15px', zIndex: '111' }}>

--- a/src/redux/flow/interfaces/flowStateInterfaces.ts
+++ b/src/redux/flow/interfaces/flowStateInterfaces.ts
@@ -3,6 +3,7 @@ import { Edge, Node } from 'reactflow';
 export interface FlowState {
   pages: Page[];
   currentPageId: string;
+  selectedNodes: string[];
 }
 
 export interface Page {

--- a/src/redux/flow/slice/flowSlice.ts
+++ b/src/redux/flow/slice/flowSlice.ts
@@ -18,6 +18,7 @@ import { NodeData } from '../constants/constants';
 const initialState: FlowState = {
   pages: null,
   currentPageId: null,
+  selectedNodes: [],
 };
 
 export const flowSlice = createSlice({
@@ -85,6 +86,15 @@ export const flowSlice = createSlice({
 
     onChangePage: (state, action: PayloadAction<string>) => {
       state.currentPageId = action.payload;
+    },
+    onSelectNode: (state, action: PayloadAction<string>) => {
+      state.selectedNodes = [action.payload];
+    },
+    onReleaseNode: (state, action: PayloadAction<string>) => {
+      state.selectedNodes = state.selectedNodes.filter((nodeId) => nodeId !== action.payload);
+    },
+    onReleaseNodes: (state) => {
+      state.selectedNodes = [];
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
Убрал eventListener из useEffect. Вместо этого все инвенты повесил на клил. Так вроде баг не встречается уже. К тому же нам в любом случае нужно знать о выделенных нодах, чтобы их копировать, дублировать ну и в целом реализовать функционал выделения сразу нескольких. Что думаешь?